### PR TITLE
[BUGFIX] Fixes instanceof in DEBUG

### DIFF
--- a/addon/-private/util.ts
+++ b/addon/-private/util.ts
@@ -61,3 +61,21 @@ export function consumeKey(obj: object, key: unknown) {
 export function dirtyKey(obj: object, key: unknown) {
   dirtyTag(getOrCreateTag(obj, key));
 }
+
+//////////
+
+export function createDebugProxy(target: any, constructor: any) {
+  return new Proxy(target, {
+    get(target, prop) {
+      if (typeof (target as any)[prop] === 'function') {
+        return (target as any)[prop].bind(target);
+      }
+
+      return (target as any)[prop];
+    },
+
+    getPrototypeOf() {
+      return constructor.prototype;
+    }
+  })
+}

--- a/tests/unit/instanceof-test.js
+++ b/tests/unit/instanceof-test.js
@@ -1,0 +1,22 @@
+import { TrackedMap, TrackedWeakMap, TrackedSet, TrackedWeakSet } from 'tracked-maps-and-sets';
+
+import { module, test } from 'qunit';
+
+module('TrackedMap', () => {
+  test('instanceof works correctly', assert => {
+    let map = new TrackedMap();
+    let set = new TrackedSet();
+    let weakMap = new TrackedWeakMap();
+    let weakSet = new TrackedWeakSet();
+
+    assert.ok(map instanceof Map, 'map is instanceof Map');
+    assert.ok(set instanceof Set, 'set is instanceof Set');
+    assert.ok(weakMap instanceof WeakMap, 'weakMap is instanceof WeakMap');
+    assert.ok(weakSet instanceof WeakSet, 'weakSet is instanceof WeakSet');
+
+    assert.notOk(map instanceof TrackedMap, 'map is not instanceof TrackedMap');
+    assert.notOk(set instanceof TrackedSet, 'set is not instanceof TrackedSet');
+    assert.notOk(weakMap instanceof TrackedWeakMap, 'weakMap is not instanceof TrackedWeakMap');
+    assert.notOk(weakSet instanceof TrackedWeakSet, 'weakSet is not instanceof TrackedWeakSet');
+  });
+});


### PR DESCRIPTION
Maps and Sets should return true for instanceof their base types, but
_not_ for instanceof on their exact types. This is because users should
not be attempting to infer whether or not a value is tracked or not.
Tracking should be completely transparent.