### PR TITLE
[BUGFIX] Uses unknown rather than any for default types

### DIFF
--- a/addon/-private/map.ts
+++ b/addon/-private/map.ts
@@ -5,7 +5,7 @@ import {
   dirtyCollection
 } from './util';
 
-export class TrackedMap<K = any, V = any> extends Map<K, V> {
+export class TrackedMap<K = unknown, V = unknown> extends Map<K, V> {
   // **** KEY GETTERS ****
   get(key: K) {
     consumeKey(this, key);
@@ -85,7 +85,7 @@ if (typeof Symbol !== undefined) {
   });
 }
 
-export class TrackedWeakMap<K extends object = object, V = any> extends WeakMap<
+export class TrackedWeakMap<K extends object = object, V = unknown> extends WeakMap<
   K,
   V
 > {

--- a/addon/-private/set.ts
+++ b/addon/-private/set.ts
@@ -5,7 +5,7 @@ import {
   dirtyCollection
 } from './util';
 
-export class TrackedSet<T = any> extends Set<T> {
+export class TrackedSet<T = unknown> extends Set<T> {
   // **** KEY GETTERS ****
   has(value: T) {
     consumeKey(this, value);


### PR DESCRIPTION
This is a better practice in general, and I only went with `any` because it matched the built-in types. I am now thinking that the built-in types are what they are because of backwards compat, so this is probably a better move.