### PR TITLE
Correct the Ember support version in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ apps and have changes automatically propagate!
 Compatibility
 ------------------------------------------------------------------------------
 
-* Ember.js v3.12 or above
+* Ember.js v3.16 or above
 * Ember CLI v2.13 or above
 * Node.js v10 or above
 


### PR DESCRIPTION
Fixes #6: this could never work on Ember 3.12, as the relevant primitives weren't available as public API in the framework yet!