### PR TITLE
Set up new Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: '/'
+    schedule:
+      interval: daily


### PR DESCRIPTION
The existing Dependabot config via the old Dependabot preview will be superceded by the GitHub integrated bot with this change.