### PR TITLE
Type check all TS versions since 3.7 in CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -79,7 +79,7 @@ jobs:
     continue-on-error: false
     strategy:
       matrix:
-        ts-version: ['4.1', '4.2', 'next']
+        ts-version: ['3.7', '3.8', '3.9', '4.0', '4.1', '4.2', 'next']
 
     steps:
       - uses: actions/checkout@v2

--- a/config/ember-try-typescript.js
+++ b/config/ember-try-typescript.js
@@ -3,6 +3,30 @@ module.exports = {
   command: 'tsc --noEmit',
   scenarios: [
     {
+      name: 'ts-3.7',
+      npm: {
+        typescript: '~3.7',
+      },
+    },
+    {
+      name: 'ts-3.8',
+      npm: {
+        typescript: '~3.8',
+      },
+    },
+    {
+      name: 'ts-3.9',
+      npm: {
+        typescript: '~3.9',
+      },
+    },
+    {
+      name: 'ts-4.0',
+      npm: {
+        typescript: '~4.0',
+      },
+    },
+    {
       name: 'ts-4.1',
       npm: {
         typescript: '~4.1',


### PR DESCRIPTION
The package was authored against 3.7.5, and continues to work correctly against the 4.3 nightlies, so it's reasonable to check it against all the intermediate versions as well. This makes the contract explicit, even if there is no formal testing of the public API (#32) yet.