### PR TITLE
Switch to `prepare` npm script

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "start": "ember serve",
     "test": "yarn build:ts && ember test",
     "test:all": "ember try:each",
-    "prepublish": "yarn build:ts"
+    "prepare": "yarn build:ts"
   },
   "dependencies": {
     "@glimmer/tracking": "^1.0.0",


### PR DESCRIPTION
Per the output of `npm publish . --tag latest --dry-run`:

> ERROR npm WARN prepublish-on-install As of npm@5, `prepublish` scripts are deprecated.
> npm WARN prepublish-on-install Use `prepare` for build steps and `prepublishOnly` for upload-only.
> npm WARN prepublish-on-install See the deprecation note in `npm help scripts` for more information.

`prepublishOnly` is the standard replacement for this, and matches what e.g. `ember-cli-typescript` does, but the build pipeline here is a bit different from that flow: it generates both CommonJS output and Ember addon output via a build command. Accordingly `prepare` is the right option.