### PR TITLE
Fix Ember global deprecation

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
   },
   "dependencies": {
     "@glimmer/tracking": "^1.0.0",
-    "ember-cli-babel": "^7.26.5"
+    "ember-cli-babel": "^7.26.5",
+    "ember-compatibility-helpers": "^1.2.4"
   },
   "devDependencies": {
     "@ember/optional-features": "^2.0.0",

--- a/src/-private/util.ts
+++ b/src/-private/util.ts
@@ -1,4 +1,5 @@
 import { tracked } from '@glimmer/tracking';
+import { gte } from 'ember-compatibility-helpers';
 
 class Tag {
   @tracked private __tag_value__: undefined;
@@ -35,7 +36,7 @@ export let dirtyCollection = (obj: object): void => {
 
 declare const Ember: any;
 
-if (typeof Ember !== 'undefined') {
+if (!gte('3.24.0')) {
   // eslint-disable-next-line ember/new-module-imports
   consumeCollection = (obj): void => Ember.get(obj, '[]');
   // eslint-disable-next-line ember/new-module-imports

--- a/yarn.lock
+++ b/yarn.lock
@@ -4816,6 +4816,16 @@ ember-compatibility-helpers@^1.1.2:
     ember-cli-version-checker "^2.1.1"
     semver "^5.4.1"
 
+ember-compatibility-helpers@^1.2.4:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/ember-compatibility-helpers/-/ember-compatibility-helpers-1.2.4.tgz#70e0fef7048969141626eed6006f3880df612cd1"
+  integrity sha512-qjzQVtogyYJrSs6I4DuyCDwDCaj5JWBVNPoZDZBk8pt7caNoN0eBYRYJdin95QKaNMQODxTLPWaI4UUDQ1YWhg==
+  dependencies:
+    babel-plugin-debug-macros "^0.2.0"
+    ember-cli-version-checker "^5.1.1"
+    fs-extra "^9.1.0"
+    semver "^5.4.1"
+
 ember-disable-prototype-extensions@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/ember-disable-prototype-extensions/-/ember-disable-prototype-extensions-1.1.3.tgz#1969135217654b5e278f9fe2d9d4e49b5720329e"


### PR DESCRIPTION
Use a version guard to entangle and notify the `[]` tag in apps that require it instead of checking for the Ember global.

Fixes #80.