### PR TITLE
Update Compatibility in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ apps and have changes automatically propagate!
 Compatibility
 ------------------------------------------------------------------------------
 
-* Ember.js v3.16 or above
+* Ember.js v3.24 or above
 * Ember CLI v2.13 or above
-* Node.js v10 or above
+* Node.js v12 or above
 
 
 Installation


### PR DESCRIPTION
I think #103 dropped support for node 10 and Ember <3.24LTS, which isn't reflected in the docs yet.